### PR TITLE
Fix incorrect test for _01_05_OneAway and add test for identical strings

### DIFF
--- a/src/test/java/arraystring/_01_05_OneAwayTest.java
+++ b/src/test/java/arraystring/_01_05_OneAwayTest.java
@@ -11,7 +11,7 @@ public class _01_05_OneAwayTest {
 
     @Test
     public void withEmpty() {
-        assertTrue(s.isOneAway("", ""));
+        assertFalse(s.isOneAway("", ""));
     }
 
     @Test
@@ -42,5 +42,10 @@ public class _01_05_OneAwayTest {
     @Test
     public void withMoreEdits() {
         assertFalse(s.isOneAway("paxye", "pamne"));
+    }
+
+    @Test
+    public void withNoEdits() {
+        assertFalse(s.isOneAway("pales", "pales"));
     }
 }


### PR DESCRIPTION
Hi,
based on the exercise description we should only evaluate to true, if two strings are one edit away from each other. Two empty strings are not, they are identical.
I added one more test that checks that two **identical non-empty** strings are evaluated as not one edit away from each other.

If you're happy with this, feel free to pull.